### PR TITLE
feat: Added explanation for Apple Silicon Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,22 @@ docker run -it --rm -p 3000:3000 --name sbv2 \
 ghcr.io/tuna2134/sbv2-api:cpu
 ```
 
+<details>
+<summary>Apple Silicon搭載のMac(M1以降)の場合</summary>
+docker上で動作させる場合、.envのADDRをlocalhostから0.0.0.0に変更してください。
+
+```yaml
+ADDR=0.0.0.0:3000
+```
+
+CPUの場合は
+```bash
+docker run --platform linux/amd64 -it --rm -p 3000:3000 --name sbv2 \
+-v ./models:/work/models --env-file .env \
+ghcr.io/tuna2134/sbv2-api:cpu
+```
+</details>
+
 CUDAの場合は
 ```sh
 docker run -it --rm -p 3000:3000 --name sbv2 \


### PR DESCRIPTION
# Apple Silicon向け対応
Apple Silicon macの環境でdockerコンテナを起動させる場合いくつか手順が必要なためREADMEに追記しました。

## 変更内容
- ARM対応のため、platformを `linux/amd64` に指定した起動コマンドを追記
- sampleのenvのままだとホスト(mac)側から疎通できないため、0.0.0.0 でサーバーを立てるよう変更するよう補足説明を追記